### PR TITLE
Correct path to search.views

### DIFF
--- a/searchlight_ui/dashboards/project/search/urls.py
+++ b/searchlight_ui/dashboards/project/search/urls.py
@@ -15,10 +15,10 @@
 from django.conf.urls import patterns
 from django.conf.urls import url
 
-from openstack_dashboard.dashboards.project.search import views
+from searchlight_ui.dashboards.project.search import views
 
 
 urlpatterns = patterns(
-    'openstack_dashboard.dashboards.project.search.views',
+    'searchlight_ui.dashboards.project.search.views',
     url(r'^$', views.IndexView.as_view(), name='index'),
 )


### PR DESCRIPTION
urls.py is incorrectly trying to import
openstack_dashboard.dashboards.project.search which doesn't exist; patch
changes first path component to searchlight_ui
